### PR TITLE
proxmox-ve updated

### DIFF
--- a/proxmox-ve/create-template-via-cloudinit.sh
+++ b/proxmox-ve/create-template-via-cloudinit.sh
@@ -58,7 +58,8 @@ read -p "Enter a SSH KEY Name for Clients [Click enter to use default ssh client
 SSHKEY_CLIENT_NAME=${SSHKEY_CLIENT_NAME:-$SSHKEY_DEFAULT_CLIENT_NAME}
 SSHKEY_CLIENT=~/.ssh/$SSHKEY_CLIENT_NAME.pub   # DO NOT USE ~/.ssh/id_rsa.pub
 if [[ ! -f $SSHKEY_CLIENT ]] ; then
-  ssh-keygen -f ~/.ssh/$SSHKEY_CLIENT_NAME -t rsa -b 4096 -P client -C "Client@VM"
+  ssh-keygen -f ~/.ssh/$SSHKEY_CLIENT_NAME -t rsa -b 4096 -C "Client@VM"
+  #ssh-keygen -f ~/.ssh/$SSHKEY_CLIENT_NAME -t rsa -b 4096 -P client -C "Client@VM"
   printf "$SSHKEY_CLIENT generated\n\n"
 else
   printf "$SSHKEY_CLIENT IS EXISTS\n\n"

--- a/proxmox-ve/sample-cloud-init-config.yml
+++ b/proxmox-ve/sample-cloud-init-config.yml
@@ -18,12 +18,12 @@ users:
     ssh_authorized_keys:
           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDJxGF1RZCyWkK5jsRGjMsCOkrkRcbzh5QYNDrj7uQty/2/iNF9RSvOmOjww164/FOYl72atXdOrnzcyYZcknNGClMcoSQKmaSSsLXswDeB7cUKqjMmDuoP5m6GPiNDL6mi0tBtXCwEoyl19wmHC6/w9DGmrNy+bwX36O5xG6o+OEjBVCxz+Bh4jUpgS1rfxAWXEZ+iJ0F5Fu8iOjl8QV2o6moNjsz7mmBoBaj/mdmjDGJG9nr/afQBvFcirhBLRVcLHNVE8yH2ybB2oh9nzMC7geOQ8DXbAetVZiAlQlybxOHGxNTCao2M34oYEx2hNrUUsU3Sh4EJQ0wJwItG90iFXZeEe4LFjzwhysb3jDlyZmO5aQBkgu1mafYGzOwlT2Dnhi3hadhkN3ruEcXlshI2VcpKSue3IARyLTD6vE48KUQR0s1MSrH+7Iox3Ahl6IcGW7XibhbHQwa0NcZTcQQ/1croGhIew0c4lhledhib6qiID+F3YLggSiRwfqcD9F9nI6eNQdZ5X7x6B5lpHz49IyEgvSh8SQwCoA8MRv8XhLR7uE35JIEKVtgNKTsQwM67BMD0GQkwrkraKodTZ5kq0ENR3AhI3WDv874q+ncFhwOl60V5C/n9eGKMgTCgFw/VEYC9ZxLmDXXLJF5tLF5lq9OQ7SaGLsFd4VeMrB4qSw== Client@VM
 runcmd:
-  sudo systemctl start qemu-guest-agent.service
-  #- sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin no/' /etc/ssh/sshd_config
-  #- sed -i 's|[#]*PasswordAuthentication yes|PasswordAuthentication no|g' /etc/ssh/sshd_config
-  #- sed -i 's|UsePAM yes|UsePAM no|g' /etc/ssh/sshd_config
-  #- restart ssh
-  #- curl -L https://omnitruck.chef.io/install.sh | bash
+  - sudo systemctl start qemu-guest-agent
+  - sudo systemctl enable qemu-guest-agent
+  - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i 's|[#]*PasswordAuthentication yes|PasswordAuthentication no|g' /etc/ssh/sshd_config
+  - sed -i 's|UsePAM yes|UsePAM no|g' /etc/ssh/sshd_config
+  - restart ssh
 final_message: "The system is finally up, after $UPTIME seconds"
 # CentOS on Digital Ocean not working for some reason but Ubuntu 14.04 does
 # cloud-init logs: /var/log/cloud-init.log and /var/log/cloud-init-output.log


### PR DESCRIPTION
### create-template-via-cloudinit.sh updated
- Packer doesn't support passphrase. So deleted from key gen.
Packer Error `ssh_private_key_file is invalid: Error setting up SSH config: ssh: this private key is passphrase protected`
### sample-cloud.init.yml updated